### PR TITLE
fix: Add support for openssl on nixos with nix-ld

### DIFF
--- a/lua/live-share/collab/crypto.lua
+++ b/lua/live-share/collab/crypto.lua
@@ -13,7 +13,13 @@ end
 
 -- Try common library names across Linux, macOS, Windows
 local lib
-for _, name in ipairs({ "crypto", "libcrypto.so.3", "libcrypto.so.1.1", "libcrypto.dylib" }) do
+for _, name in ipairs({
+  "crypto",
+  "libcrypto.so.3",
+  "libcrypto.so.1.1",
+  "libcrypto.dylib",
+  "/run/current-system/sw/share/nix-ld/lib/libcrypto.so",
+}) do
   local ok, l = pcall(ffi.load, name)
   if ok then lib = l; break end
 end


### PR DESCRIPTION
I was trying this out on nixos and it couldn't find the openssl libs. This is due to nixos's peculiarities with FHS directories. There is a nix-ld workaround but that only works if I add this as an explicit path in the table. There might be a better more holistic fix but this should add support for anyone on nix with the below configuration, and introduces only minimal non instrusive changes.
```
programs.nix-ld.enable = true;
programs.nix-ld.libraries = with pkgs; [
  openssl
];
```

